### PR TITLE
Build a filebeat image to prevent permission issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,13 +50,12 @@ services:
     entrypoint: ["/usr/local/bin/docker-entrypoint-override.sh"]
     command: ["postgres", "-c", "logging_collector=on", "-c", "log_statement=all", "-c", "log_directory=/usr/share/log/", "-c", "log_filename=postgres.log"]
   filebeat:
-    image: docker.elastic.co/beats/filebeat-oss:7.10.2
+    build: filebeat
     command: ["-environment", "container"]
     environment:
       PERSONAL_ACCESS_TOKEN: 274dc2a2-5db4-4f8c-92a3-92e33bee92a8
     volumes:
       - logs:/usr/share/log:ro
-      - ./filebeat/filebeat.yml:/usr/share/filebeat/filebeat.yml
     restart: unless-stopped
 
   # Minio container + tracer + axiom cli ingestors

--- a/filebeat/Dockerfile
+++ b/filebeat/Dockerfile
@@ -1,0 +1,6 @@
+# https://www.elastic.co/guide/en/beats/filebeat/current/running-on-docker.html#_custom_image_configuration
+FROM docker.elastic.co/beats/filebeat-oss:7.10.2
+COPY filebeat.yml /usr/share/filebeat/filebeat.yml
+USER root
+RUN chown root:filebeat /usr/share/filebeat/filebeat.yml
+USER filebeat

--- a/filebeat/Dockerfile
+++ b/filebeat/Dockerfile
@@ -2,5 +2,6 @@
 FROM docker.elastic.co/beats/filebeat-oss:7.10.2
 COPY filebeat.yml /usr/share/filebeat/filebeat.yml
 USER root
-RUN chown root:filebeat /usr/share/filebeat/filebeat.yml
+RUN chown root:filebeat /usr/share/filebeat/filebeat.yml && \
+    chmod go-w /usr/share/filebeat/filebeat.yml
 USER filebeat


### PR DESCRIPTION
Some users got Filebeat errors due to `filebeat.yml` not being owned by the user (UID 1000) so this fixes it by copying the file instead and giving it proper permissions.